### PR TITLE
Create Jetty9 Containers, Add Profiler tagged containers to Jetty9 and Tomcat7

### DIFF
--- a/docker-jetty-java8-download/Dockerfile
+++ b/docker-jetty-java8-download/Dockerfile
@@ -33,6 +33,7 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8 
+ENV JAVA_HOME /usr/lib/jvm/zulu-8-amd64/
 
 ADD https://s3.amazonaws.com/aws-cli/awscli-bundle.zip /tmp/
 RUN unzip /tmp/awscli-bundle.zip -d /tmp \

--- a/docker-jetty-java8/Dockerfile
+++ b/docker-jetty-java8/Dockerfile
@@ -33,6 +33,7 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8 
+ENV JAVA_HOME /usr/lib/jvm/zulu-8-amd64/
 
 # Run Jetty
 CMD ["/opt/start-jetty.sh"]

--- a/docker-jetty9-java8-download/Dockerfile
+++ b/docker-jetty9-java8-download/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get -qq upgrade
 
 RUN apt-get -qq install curl bash unzip
 RUN apt-get -qq install default-jdk 
+RUN apt-get -qq install supervisor
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 ADD start-jetty.sh /opt/start-jetty.sh
 RUN chmod +x /opt/start-jetty.sh

--- a/docker-jetty9-java8-download/Dockerfile
+++ b/docker-jetty9-java8-download/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:16.04
+MAINTAINER Maluuba Infrastructure Team <infrastructure@maluuba.com>
+
+EXPOSE 8080
+
+# Required for apt-add-repository
+RUN apt-get -qq update
+RUN apt-get -qq install software-properties-common python-software-properties
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN apt-get -qq update
+RUN apt-get -qq upgrade
+
+RUN apt-get -qq install curl bash unzip
+RUN apt-get -qq install default-jdk 
+
+ADD start-jetty.sh /opt/start-jetty.sh
+RUN chmod +x /opt/start-jetty.sh
+
+# Install Jetty
+ADD http://download.eclipse.org/jetty/9.3.8.v20160314/dist/jetty-distribution-9.3.8.v20160314.tar.gz /opt/jetty.tar.gz
+RUN tar -xvf /opt/jetty.tar.gz -C /opt/
+RUN rm /opt/jetty.tar.gz
+RUN mv /opt/jetty-distribution-* /opt/jetty
+RUN rm -rf /opt/jetty/webapps.demo
+RUN useradd jetty -U -s /bin/false
+RUN chown -R jetty:jetty /opt/jetty
+
+# Setup UTF * based terminal
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8 
+
+RUN mkdir /etc/jetty &&  mkdir /etc/jetty/webapps && mkdir /etc/jetty/config 
+ADD https://s3.amazonaws.com/aws-cli/awscli-bundle.zip /tmp/
+RUN unzip /tmp/awscli-bundle.zip -d /tmp \
+&& /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+
+# Run Jetty
+CMD ["/opt/start-jetty.sh"]

--- a/docker-jetty9-java8-download/README.md
+++ b/docker-jetty9-java8-download/README.md
@@ -1,0 +1,55 @@
+# docker-jetty9-java8
+
+Dockerfile for setting up [Docker](https://github.com/docker/docker) container with [Jetty](http://www.eclipse.org/jetty/) installed.
+
+Versions:
+
+* Jetty 9.3.8.v20160314 
+
+## Pulling
+
+    $ docker pull maluuba/jetty9-java8
+
+## Running
+
+    $ docker run -d -p 8080:8080 -i -t maluuba/jetty9-java8
+
+Then point your browser at [http://localhost:8080/](http://localhost:8080/)
+or [http://192.168.59.103:8080/](http://192.168.59.103:8080/) if you are using boot2docker
+
+Optionally you can create a local folder with sub-folders for: webapps, config and contexts. Copy your war files into __webapps__, your context xmls into __contexts__ and any custom config to be copies into ../jetty/etc/ into __config__. In addition if you put a script called init.sh at __/etc/jetty/init.sh__ it will be executed before jetty is run. This can be used to perform any custom setup steps.   
+
+    $mkdir /local/jetty
+    $mkdir /local/jetty/webapps
+    $mkdir /local/jetty/config
+    $mkdir /local/jetty/contexts
+    
+    $ docker run -d -p 8080:8080 -v /local/jetty:/etc/jetty -i -t maluuba/jetty-java8
+
+
+    
+## Building
+
+From sources:
+
+    $ docker build github.com/maluuba/docker-jetty9-java8
+    
+## Author
+
+  * Nick Ma (http://github.com/nma)
+
+## LICENSE
+
+Copyright 2016 Maluuba
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.    

--- a/docker-jetty9-java8-download/start-jetty.sh
+++ b/docker-jetty9-java8-download/start-jetty.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+
+echo "Setting up AWS Client"
+
+mkdir -p ~/.aws
+cat <<EOF > ~/.aws/credentials
+[default]
+aws_access_key_id = ${AWS_KEY}
+aws_secret_access_key = ${AWS_SECRET}
+EOF
+
+cat <<EOF > ~/.aws/config
+[default]
+output = json
+region = us-east-1
+EOF
+
+echo "Downloading jetty war"
+rm -rf /opt/jetty/webapps/*
+aws s3 cp s3://${S3_PATH} /opt/jetty/webapps/${LOCAL_PATH}.war
+
+echo "Downloading custom config"
+rm -rf /opt/jetty/contexts/*
+aws s3 cp s3://${S3_LOGGING_PATH} /opt/jetty/etc/logging.xml
+aws s3 cp s3://${S3_CONTEXT_PATH} /opt/jetty/contexts/${LOCAL_PATH}.xml
+
+echo "${USER}: MD5:${PASSWORD_HASH},moderator,oem-user" > opt/jetty/etc/${REALM_NAME}-realm.properties
+
+if [[ -n ${JAVA_OPTIONS} ]];
+then
+    echo "export JAVA_OPTIONS=\"\$\{JAVA_OPTIONS\} ${JAVA_OPTIONS}\""  >> /etc/default/jetty
+fi
+
+/opt/jetty/bin/jetty.sh run

--- a/docker-jetty9-java8-download/start-jetty.sh
+++ b/docker-jetty9-java8-download/start-jetty.sh
@@ -32,4 +32,4 @@ then
     echo "export JAVA_OPTIONS=\"\$\{JAVA_OPTIONS\} ${JAVA_OPTIONS}\""  >> /etc/default/jetty
 fi
 
-/opt/jetty/bin/jetty.sh run
+/usr/bin/supervisord

--- a/docker-jetty9-java8-download/supervisord.conf
+++ b/docker-jetty9-java8-download/supervisord.conf
@@ -1,0 +1,7 @@
+[supervisord]
+nodaemon=true
+
+[program:jetty]
+command=/opt/jetty/bin/jetty.sh run
+autostart=true
+autorestart=unexpected

--- a/docker-jetty9-java8/Dockerfile
+++ b/docker-jetty9-java8/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:16.04
+MAINTAINER Maluuba Infrastructure Team <infrastructure@maluuba.com>
+
+EXPOSE 8080
+
+# Required for apt-add-repository
+RUN apt-get -qq update
+RUN apt-get -qq install software-properties-common python-software-properties
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN apt-get -qq update
+RUN apt-get -qq upgrade
+
+RUN apt-get -qq install curl bash unzip
+RUN apt-get -qq install default-jdk 
+
+ADD start-jetty.sh /opt/start-jetty.sh
+RUN chmod +x /opt/start-jetty.sh
+
+# Install Jetty
+ADD http://download.eclipse.org/jetty/9.3.8.v20160314/dist/jetty-distribution-9.3.8.v20160314.tar.gz /opt/jetty.tar.gz
+RUN tar -xvf /opt/jetty.tar.gz -C /opt/
+RUN rm /opt/jetty.tar.gz
+RUN mv /opt/jetty-distribution-* /opt/jetty
+RUN rm -rf /opt/jetty/webapps.demo
+RUN useradd jetty -U -s /bin/false
+RUN chown -R jetty:jetty /opt/jetty
+
+# Setup UTF * based terminal
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8 
+
+RUN mkdir /etc/jetty &&  mkdir /etc/jetty/webapps && mkdir /etc/jetty/config 
+
+# Run Jetty
+CMD ["/opt/start-jetty.sh"]

--- a/docker-jetty9-java8/Dockerfile
+++ b/docker-jetty9-java8/Dockerfile
@@ -13,7 +13,9 @@ RUN apt-get -qq update
 RUN apt-get -qq upgrade
 
 RUN apt-get -qq install curl bash unzip
-RUN apt-get -qq install default-jdk 
+RUN apt-get -qq install default-jdk
+RUN apt-get -qq install supervisor
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 ADD start-jetty.sh /opt/start-jetty.sh
 RUN chmod +x /opt/start-jetty.sh

--- a/docker-jetty9-java8/README.md
+++ b/docker-jetty9-java8/README.md
@@ -1,0 +1,55 @@
+# docker-jetty-java8
+
+Dockerfile for setting up [Docker](https://github.com/dotcloud/docker) container with [Jetty](http://www.eclipse.org/jetty/) installed.
+
+Versions:
+
+* Jetty 8.1.17
+
+## Pulling
+
+    $ docker pull maluuba/jetty-java8
+
+## Running
+
+    $ docker run -d -p 8080:8080 -i -t maluuba/jetty-java8
+
+Then point your browser at [http://localhost:8080/](http://localhost:8080/)
+or [http://192.168.59.103:8080/](http://192.168.59.103:8080/) if you are using boot2docker
+
+Optionally you can create a local folder with sub-folders for: webapps, config and contexts. Copy your war files into __webapps__, your context xmls into __contexts__ and any custom config to be copies into ../jetty/etc/ into __config__. In addition if you put a script called init.sh at __/etc/jetty/init.sh__ it will be executed before jetty is run. This can be used to perform any custom setup steps.   
+
+    $mkdir /local/jetty
+    $mkdir /local/jetty/webapps
+    $mkdir /local/jetty/config
+    $mkdir /local/jetty/contexts
+    
+    $ docker run -d -p 8080:8080 -v /local/jetty:/etc/jetty -i -t maluuba/jetty-java8
+
+
+    
+## Building
+
+From sources:
+
+    $ docker build github.com/maluuba/docker-jetty-java8
+    
+## Author
+
+  * Justin Harris (http://github.com/juharris)
+
+## LICENSE
+
+Copyright 2015 Maluuba
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.    

--- a/docker-jetty9-java8/README.md
+++ b/docker-jetty9-java8/README.md
@@ -1,18 +1,18 @@
-# docker-jetty-java8
+# docker-jetty9-java8
 
-Dockerfile for setting up [Docker](https://github.com/dotcloud/docker) container with [Jetty](http://www.eclipse.org/jetty/) installed.
+Dockerfile for setting up [Docker](https://github.com/docker/docker) container with [Jetty](http://www.eclipse.org/jetty/) installed.
 
 Versions:
 
-* Jetty 8.1.17
+* Jetty 9.3.8.v20160314 
 
 ## Pulling
 
-    $ docker pull maluuba/jetty-java8
+    $ docker pull maluuba/jetty9-java8
 
 ## Running
 
-    $ docker run -d -p 8080:8080 -i -t maluuba/jetty-java8
+    $ docker run -d -p 8080:8080 -i -t maluuba/jetty9-java8
 
 Then point your browser at [http://localhost:8080/](http://localhost:8080/)
 or [http://192.168.59.103:8080/](http://192.168.59.103:8080/) if you are using boot2docker
@@ -32,15 +32,15 @@ Optionally you can create a local folder with sub-folders for: webapps, config a
 
 From sources:
 
-    $ docker build github.com/maluuba/docker-jetty-java8
+    $ docker build github.com/maluuba/docker-jetty9-java8
     
 ## Author
 
-  * Justin Harris (http://github.com/juharris)
+  * Nick Ma (http://github.com/nma)
 
 ## LICENSE
 
-Copyright 2015 Maluuba
+Copyright 2016 Maluuba
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docker-jetty9-java8/profiler/Dockerfile
+++ b/docker-jetty9-java8/profiler/Dockerfile
@@ -1,0 +1,23 @@
+FROM maluuba/jetty9-java8
+MAINTAINER Maluuba Infrastructure Team <infrastructure@maluuba.com>
+
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+ENV NEW_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=62911,server=y,suspend=n \
+              -Dcom.sun.management.jmxremote=true \
+              -Dcom.sun.management.jmxremote.ssl=false \
+              -Dcom.sun.management.jmxremote.authenticate=false \
+              -Dcom.sun.management.jmxremote.rmi.port=1898 \
+              -Dcom.sun.management.jmxremote.port=1098
+
+COPY jstatd.all.policy $JAVA_HOME/jstatd.policy
+COPY start-jetty-profiler.sh /opt/start-jetty-profiler.sh
+RUN chmod +x /opt/start-jetty-profiler.sh
+RUN echo "JAVA_OPTIONS=\"\${JAVA_OPTS} ${NEW_JAVA_OPTS} \""  >> /etc/default/jetty
+
+EXPOSE 1099
+EXPOSE 1098
+EXPOSE 1898
+EXPOSE 62911
+
+ENTRYPOINT ["/opt/start-jetty-profiler.sh"]

--- a/docker-jetty9-java8/profiler/README.md
+++ b/docker-jetty9-java8/profiler/README.md
@@ -1,0 +1,55 @@
+# docker-jetty-java8
+
+Dockerfile for setting up [Docker](https://github.com/dotcloud/docker) container with [Jetty](http://www.eclipse.org/jetty/) installed.
+
+Versions:
+
+* Jetty 8.1.17
+
+## Pulling
+
+    $ docker pull maluuba/jetty-java8
+
+## Running
+
+    $ docker run -d -p 8080:8080 -i -t maluuba/jetty-java8
+
+Then point your browser at [http://localhost:8080/](http://localhost:8080/)
+or [http://192.168.59.103:8080/](http://192.168.59.103:8080/) if you are using boot2docker
+
+Optionally you can create a local folder with sub-folders for: webapps, config and contexts. Copy your war files into __webapps__, your context xmls into __contexts__ and any custom config to be copies into ../jetty/etc/ into __config__. In addition if you put a script called init.sh at __/etc/jetty/init.sh__ it will be executed before jetty is run. This can be used to perform any custom setup steps.   
+
+    $mkdir /local/jetty
+    $mkdir /local/jetty/webapps
+    $mkdir /local/jetty/config
+    $mkdir /local/jetty/contexts
+    
+    $ docker run -d -p 8080:8080 -v /local/jetty:/etc/jetty -i -t maluuba/jetty-java8
+
+
+    
+## Building
+
+From sources:
+
+    $ docker build github.com/maluuba/docker-jetty-java8
+    
+## Author
+
+  * Justin Harris (http://github.com/juharris)
+
+## LICENSE
+
+Copyright 2015 Maluuba
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.    

--- a/docker-jetty9-java8/profiler/jstatd.all.policy
+++ b/docker-jetty9-java8/profiler/jstatd.all.policy
@@ -1,0 +1,3 @@
+grant codebase "file:/usr/lib/jvm/java-8-openjdk-amd64/lib/tools.jar" {
+   permission java.security.AllPermission;
+};

--- a/docker-jetty9-java8/profiler/start-jetty-profiler.sh
+++ b/docker-jetty9-java8/profiler/start-jetty-profiler.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+if [ -d /etc/jetty/webapps ];
+then
+	echo "Copying jetty wars"
+	rm -rf /opt/jetty/webapps/*
+	cp /etc/jetty/webapps/* /opt/jetty/webapps
+fi
+
+# If custom Jetty config folder mapped copy files into jetty/etc/
+if [ -d /etc/jetty/config ];
+then
+	echo "Copying custom config"
+	cp /etc/jetty/config/* /opt/jetty/etc/
+fi
+
+# If custom Jetty context folder mapped copy files into jetty/contexts/
+if [ -d /etc/jetty/contexts ];
+then
+	echo "Copying custom Contexts"
+	rm -rf /opt/jetty/contexts/*
+	cp /etc/jetty/contexts/* /opt/jetty/contexts/
+fi
+
+
+# If check if custom init script exists
+if [ -e /etc/jetty/init.sh ];
+then
+	echo "Running custom init script"
+	chmod +x /etc/jetty/init.sh
+	/etc/jetty/init.sh
+fi
+
+#Override the exit command to prevent accidental container distruction 
+echo 'alias exit="echo Are you sure? this will kill the container. use Ctrl + p, Ctrl + q to detach or ctrl + d to exit"' > ~/.bashrc
+
+/opt/jetty/bin/jetty.sh run &
+
+#Start jstatd in background
+jstatd -J-Djava.security.policy=$JAVA_HOME/jstatd.policy &
+
+#Run bash to keep container running and provide interactive mode
+bash

--- a/docker-jetty9-java8/profiler/start-jetty-profiler.sh
+++ b/docker-jetty9-java8/profiler/start-jetty-profiler.sh
@@ -22,7 +22,6 @@ then
 	cp /etc/jetty/contexts/* /opt/jetty/contexts/
 fi
 
-
 # If check if custom init script exists
 if [ -e /etc/jetty/init.sh ];
 then
@@ -34,10 +33,8 @@ fi
 #Override the exit command to prevent accidental container distruction 
 echo 'alias exit="echo Are you sure? this will kill the container. use Ctrl + p, Ctrl + q to detach or ctrl + d to exit"' > ~/.bashrc
 
-/opt/jetty/bin/jetty.sh run &
-
 #Start jstatd in background
 jstatd -J-Djava.security.policy=$JAVA_HOME/jstatd.policy &
 
 #Run bash to keep container running and provide interactive mode
-bash
+/usr/bin/supervisord 

--- a/docker-jetty9-java8/start-jetty.sh
+++ b/docker-jetty9-java8/start-jetty.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+if [ -d /etc/jetty/webapps ];
+then
+	echo "Copying jetty wars"
+	rm -rf /opt/jetty/webapps/*
+	cp /etc/jetty/webapps/* /opt/jetty/webapps
+fi
+
+# If custom Jetty config folder mapped copy files into jetty/etc/
+if [ -d /etc/jetty/config ];
+then
+	echo "Copying custom config"
+	cp /etc/jetty/config/* /opt/jetty/etc/
+fi
+
+# If custom Jetty context folder mapped copy files into jetty/contexts/
+if [ -d /etc/jetty/contexts ];
+then
+	echo "Copying custom Contexts"
+	rm -rf /opt/jetty/contexts/*
+	cp /etc/jetty/contexts/* /opt/jetty/contexts/
+fi
+
+
+# If check if custom init script exists
+if [ -e /etc/jetty/init.sh ];
+then
+	echo "Running custom init script"
+	chmod +x /etc/jetty/init.sh
+	/etc/jetty/init.sh
+fi
+
+
+/opt/jetty/bin/jetty.sh run

--- a/docker-jetty9-java8/start-jetty.sh
+++ b/docker-jetty9-java8/start-jetty.sh
@@ -31,5 +31,4 @@ then
 	/etc/jetty/init.sh
 fi
 
-
-/opt/jetty/bin/jetty.sh run
+/usr/bin/supervisord

--- a/docker-jetty9-java8/supervisord.conf
+++ b/docker-jetty9-java8/supervisord.conf
@@ -1,0 +1,7 @@
+[supervisord]
+nodaemon=true
+
+[program:jetty]
+command=/opt/jetty/bin/jetty.sh run
+autostart=true
+autorestart=unexpected

--- a/docker-tomcat7-java8-download/Dockerfile
+++ b/docker-tomcat7-java8-download/Dockerfile
@@ -30,6 +30,7 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8  
 ENV LANGUAGE en_US:en  
 ENV LC_ALL en_US.UTF-8
+ENV JAVA_HOME /usr/lib/jvm/zulu-8-amd64/
 
 ADD https://s3.amazonaws.com/aws-cli/awscli-bundle.zip /tmp/
 RUN unzip /tmp/awscli-bundle.zip -d /tmp \

--- a/docker-tomcat7-java8-download/start-tomcat.sh
+++ b/docker-tomcat7-java8-download/start-tomcat.sh
@@ -48,5 +48,5 @@ fi
 
 chown tomcat7:tomcat7 /deployment
 service tomcat7 restart
-bash
 
+tail -f /var/log/tomcat7/catalina.out

--- a/docker-tomcat7-java8/Dockerfile
+++ b/docker-tomcat7-java8/Dockerfile
@@ -32,5 +32,6 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8  
 ENV LANGUAGE en_US:en  
 ENV LC_ALL en_US.UTF-8  
+ENV JAVA_HOME /usr/lib/jvm/zulu-8-amd64/
 
 ENTRYPOINT ["/opt/start-tomcat.sh"]

--- a/docker-tomcat7-java8/profiler/Dockerfile
+++ b/docker-tomcat7-java8/profiler/Dockerfile
@@ -1,0 +1,23 @@
+FROM maluuba/tomcat7-java8
+MAINTAINER Maluuba Infrastructure Team <infrastructure@maluuba.com>
+
+
+ENV JAVA_HOME /usr/lib/jvm/zulu-8-amd64/
+ENV NEW_JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address=62911,server=y,suspend=n \
+              -Dcom.sun.management.jmxremote=true \
+              -Dcom.sun.management.jmxremote.ssl=false \
+              -Dcom.sun.management.jmxremote.authenticate=false \
+              -Dcom.sun.management.jmxremote.rmi.port=1898 \
+              -Dcom.sun.management.jmxremote.port=1098
+
+COPY jstatd.all.policy $JAVA_HOME/jstatd.policy
+COPY start-tomcat-profiler.sh /opt/start-tomcat-profiler.sh
+RUN chmod +x /opt/start-tomcat-profiler.sh
+RUN echo "JAVA_OPTS=\"\${JAVA_OPTS} ${NEW_JAVA_OPTS} \""  >> /etc/default/tomcat7
+
+EXPOSE 1099
+EXPOSE 1098
+EXPOSE 1898
+EXPOSE 62911
+
+ENTRYPOINT ["/opt/start-tomcat-profiler.sh"]

--- a/docker-tomcat7-java8/profiler/README.md
+++ b/docker-tomcat7-java8/profiler/README.md
@@ -1,14 +1,14 @@
-# docker-jetty9-java8:profiler
+# docker-tomcat7-java8:profiler
 
-Dockerfile for setting up [Docker](https://github.com/docker/docker) container with [Jetty](http://www.eclipse.org/jetty/) installed.
+Dockerfile for setting up [Docker](https://github.com/docker/docker) container tomcat7 installed.
 
 ## Pulling
 
-    $ docker pull maluuba/jetty9-java8:profiler
+    $ docker pull maluuba/tomcat7-java8:profiler
 
 ## Running
 
-    $ docker run -d -p 8080:8080 -i -t maluuba/jetty9-java8:profiler
+    $ docker run -d -p 8080:8080 -i -t maluuba/tomcat7-java8:profiler
 
 Then point your browser at [http://localhost:8080/](http://localhost:8080/)
 or [http://192.168.59.103:8080/](http://192.168.59.103:8080/) if you are using boot2docker
@@ -17,7 +17,7 @@ or [http://192.168.59.103:8080/](http://192.168.59.103:8080/) if you are using b
 
 From sources:
 
-    $ docker build github.com/maluuba/docker-jetty9-java8/profiler
+    $ docker build github.com/maluuba/docker-tomcat7-java8/profiler
     
 ## Author
 

--- a/docker-tomcat7-java8/profiler/jstatd.all.policy
+++ b/docker-tomcat7-java8/profiler/jstatd.all.policy
@@ -1,0 +1,3 @@
+grant codebase "file:/usr/lib/jvm/zulu-8-amd64/lib/tools.jar" {
+   permission java.security.AllPermission;
+};

--- a/docker-tomcat7-java8/profiler/start-tomcat-profiler.sh
+++ b/docker-tomcat7-java8/profiler/start-tomcat-profiler.sh
@@ -43,5 +43,4 @@ echo 'alias exit="echo Are you sure? this will kill the container. use Ctrl + p,
 #Start jstatd in background
 jstatd -J-Djava.security.policy=$JAVA_HOME/jstatd.policy &
 
-#Run bash to keep container running and provide interactive mode
-bash
+tail -f /var/log/tomcat7/catalina.out

--- a/docker-tomcat7-java8/profiler/start-tomcat-profiler.sh
+++ b/docker-tomcat7-java8/profiler/start-tomcat-profiler.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+
+if [ -f /deployment/init.sh ];
+then
+        echo "Running custom init script"
+        chmod +x /deployment/init.sh
+        /deployment/init.sh
+fi
+
+if [ -d /deployment ];
+then
+        echo "Mapping deployed wars"
+        rm -rf /var/lib/tomcat7/webapps
+        ln -s /deployment /var/lib/tomcat7/webapps
+fi
+
+if [ -n "${Xmx}" ];
+then
+        sed -i s/Xmx.*\ /Xmx${Xmx}\ /g /etc/default/tomcat7
+fi
+
+if [ -n "${JAVA_OPTS}" ];
+then
+        # Add any Java opts that are set in the container
+        echo "Adding JAVA OPTS"
+        echo "JAVA_OPTS=\"\${JAVA_OPTS} ${JAVA_OPTS} \"" >> /etc/default/tomcat7
+fi
+
+if [ -n "${JAVA_HOME}" ];
+then
+	# Add java home if set in container
+	echo "Adding JAVA_HOME"
+	echo "JAVA_HOME=\"${JAVA_HOME}\"" >> /etc/default/tomcat7
+fi
+
+chown tomcat7:tomcat7 /deployment
+service tomcat7 restart
+
+#Override the exit command to prevent accidental container distruction 
+echo 'alias exit="echo Are you sure? this will kill the container. use Ctrl + p, Ctrl + q to detach or ctrl + d to exit"' > ~/.bashrc
+
+#Start jstatd in background
+jstatd -J-Djava.security.policy=$JAVA_HOME/jstatd.policy &
+
+#Run bash to keep container running and provide interactive mode
+bash


### PR DESCRIPTION
Allows the use of java8  without explicitly setting the JAVA_HOME env externally. 
